### PR TITLE
fix(docker): remove train from fschat requirements in docker scripts

### DIFF
--- a/.docker/scripts/requirements.txt
+++ b/.docker/scripts/requirements.txt
@@ -1,1 +1,1 @@
-fschat[model_worker,webui,train,llm_judge]
+fschat[model_worker,webui,llm_judge]


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>